### PR TITLE
feat: handle spaces between clauses

### DIFF
--- a/packages/az-functions/DiscordMessageHandler/handleDiscordCommand.ts
+++ b/packages/az-functions/DiscordMessageHandler/handleDiscordCommand.ts
@@ -1,4 +1,4 @@
-import { AbilityRollResult, rollCocAbility, SuccessDegree } from '@cocbot/core'
+import { AbilityRollResult, rollBrpAbility, SuccessDegree } from '@cocbot/core'
 
 export interface DiscordOption {
 	name: string
@@ -55,7 +55,7 @@ function handleDiscordRollCommand(
 	const penaltyDie = getOption(command, 'penalty', 0)
 	const label = getOption(command, 'label', '')
 
-	const rollResult = rollCocAbility(skill, bonusDie, penaltyDie)
+	const rollResult = rollBrpAbility(skill, bonusDie, penaltyDie)
 	return `<@${member.user.id}> rolled ${printRollResult(rollResult, label)}`
 }
 

--- a/packages/bot/src/Bot.ts
+++ b/packages/bot/src/Bot.ts
@@ -1,6 +1,6 @@
 import * as Discord from 'discord.js'
 import { Game } from '@cocbot/schema/lib/client-types'
-import { rollCocAbility, SuccessDegree, rollDiceExpression } from '@cocbot/core'
+import { rollBrpAbility, SuccessDegree, rollDiceExpression } from '@cocbot/core'
 import {
 	Command,
 	HelpCommand,
@@ -104,7 +104,7 @@ e.g. \`/cc roll 25b2 "handgun"\` rolls against a skill with a value of 25 labele
 			return `I can't handle ability names just yet. Try rolling against your ability value (e.g. roll against 75)`
 		} else {
 			const abilityValue = command.ability as number
-			const { rolls, result, degree } = rollCocAbility(
+			const { rolls, result, degree } = rollBrpAbility(
 				abilityValue,
 				command.bonusDice || 0,
 				command.penaltyDice || 0

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,1 @@
-export * from './dice'
-export * from './rolls'
+export * from './rolling'

--- a/packages/core/src/rolling/brp_rolls.ts
+++ b/packages/core/src/rolling/brp_rolls.ts
@@ -3,9 +3,13 @@ import {
 	RollValueExpresionClause,
 	RollExpressionOp,
 	RollExpressionClause,
+	RollExpressionOpType,
 } from '@cocbot/parser'
 import { rollD10, rollDN } from './dice'
 
+/**
+ * The success degree of a d100 roll in BRP
+ */
 export enum SuccessDegree {
 	CriticalFailure,
 	Failure,
@@ -14,14 +18,33 @@ export enum SuccessDegree {
 	ExtremeSuccess,
 	CriticalSuccess,
 }
+
+/**
+ * The result of roll in BRP
+ */
 export interface AbilityRollResult {
+	/**
+	 * The resultant value
+	 */
 	result: number
-	rolls: number[]
+
+	/**
+	 * The degree of success achieved
+	 */
 	degree: SuccessDegree
+
+	/**
+	 * The rolls that were executed. This includes any penalty or bonus die rolls
+	 */
+	rolls: number[]
+
+	/**
+	 * The die thresholds for success degrees that require calculation (e.g regular, hard & extreme successes)
+	 */
 	thresholds: Partial<Record<SuccessDegree, number>>
 }
 
-export function rollCocAbility(
+export function rollBrpAbility(
 	ability: number,
 	bonus: number,
 	penalty: number
@@ -90,9 +113,9 @@ export function rollDiceExpression(
 		const childRolls = [...rolls1, ...rolls2]
 		let numericResult = 0
 
-		if (opExpression.operation === 'subtract') {
+		if (opExpression.operation === RollExpressionOpType.Subtract) {
 			numericResult = val1 - val2
-		} else if (opExpression.operation === 'add') {
+		} else if (opExpression.operation === RollExpressionOpType.Add) {
 			numericResult = val1 + val2
 		} else {
 			throw new Error(`unhandled operation ${opExpression.operation}`)

--- a/packages/core/src/rolling/dice.ts
+++ b/packages/core/src/rolling/dice.ts
@@ -9,29 +9,52 @@ export function getRandomInt(min: number, max: number): number {
 	return Math.floor(Math.random() * (max - min) + min)
 }
 
+/**
+ * Roll an n-sided die. Values are from [1, n-1]
+ * @param sides The # of sides on the die
+ */
 export function rollDN(sides: number): number {
 	return getRandomInt(1, sides + 1)
 }
 
-export function rollD4(): number {
-	return rollDN(4)
-}
-export function rollD6(): number {
-	return rollDN(6)
-}
-export function rollD8(): number {
-	return rollDN(8)
-}
-export function rollD12(): number {
-	return rollDN(12)
-}
-export function rollD20(): number {
-	return rollDN(20)
-}
-
 /**
- * 10 sided dire are 0-9
+ * 10 sided dice are 0-9
  */
 export function rollD10(): number {
 	return getRandomInt(0, 10)
+}
+
+/**
+ * Roll a four sided die
+ */
+export function rollD4(): number {
+	return rollDN(4)
+}
+
+/**
+ * Roll a six sided die
+ */
+export function rollD6(): number {
+	return rollDN(6)
+}
+
+/**
+ * Roll an eight-sided die
+ */
+export function rollD8(): number {
+	return rollDN(8)
+}
+
+/**
+ * Roll a twelve-sided die
+ */
+export function rollD12(): number {
+	return rollDN(12)
+}
+
+/**
+ * Roll a twenty-sided die
+ */
+export function rollD20(): number {
+	return rollDN(20)
 }

--- a/packages/core/src/rolling/index.ts
+++ b/packages/core/src/rolling/index.ts
@@ -1,0 +1,2 @@
+export * from './dice'
+export * from './brp_rolls'

--- a/packages/parser/grammar/commands.ne
+++ b/packages/parser/grammar/commands.ne
@@ -39,8 +39,8 @@ diceExpr ->
   PosInt {% d => ({ value: d[0].literal }) %}
   | d PosInt {% d => ({ die: d[1].literal, count: 1 }) %}
   | PosInt d PosInt KeepHighestOrLowest {% d => ({ count: d[0].literal, die: d[2].literal, ...d[3] }) %}
-  | diceExpr plus diceExpr {% d => ({ operation: "add", operands: [d[0], d[2]]}) %}
-  | diceExpr minus diceExpr {% d => ({ operation: "subtract", operands: [d[0], d[2]]}) %}
+  | diceExpr _ plus _ diceExpr {% d => ({ operation: "add", operands: [d[0], d[4]]}) %}
+  | diceExpr _ minus _ diceExpr {% d => ({ operation: "subtract", operands: [d[0], d[4]]}) %}
 
 KeepHighestOrLowest -> 
   null {% d => ({}) %}

--- a/packages/parser/src/__tests__/parser.test.ts
+++ b/packages/parser/src/__tests__/parser.test.ts
@@ -1,4 +1,10 @@
-import { CommandType, HelpCommand, parseCommand, RollCommand } from '../parser'
+import {
+	CommandType,
+	HelpCommand,
+	parseCommand,
+	RollCommand,
+	RollExpressionOpType,
+} from '../parser'
 
 describe('The Command Parser', () => {
 	it('can handle a malformed command', () => {
@@ -14,9 +20,14 @@ describe('The Command Parser', () => {
 		})
 
 		it('can handle roll labels', () => {
-			const command = 'roll 20 # stealth'
-			const result = parseCommand<RollCommand>(command)
+			let command = 'roll 20'
+			let result = parseCommand<RollCommand>(command)
+			expect(result.type).toEqual(CommandType.Roll)
+			expect(result.ability).toEqual(20)
+			expect(result.label).toBeFalsy()
 
+			command = 'roll 20 # stealth'
+			result = parseCommand<RollCommand>(command)
 			expect(result.type).toEqual(CommandType.Roll)
 			expect(result.label).toEqual('stealth')
 		})
@@ -55,7 +66,16 @@ describe('The Command Parser', () => {
 
 			result = parseCommand<RollCommand>('roll 2d6+2d8')
 			expect(result.expr).toEqual({
-				operation: 'add',
+				operation: RollExpressionOpType.Add,
+				operands: [
+					{ die: 6, count: 2 },
+					{ die: 8, count: 2 },
+				],
+			})
+
+			result = parseCommand<RollCommand>('roll 2d6 + 2d8')
+			expect(result.expr).toEqual({
+				operation: RollExpressionOpType.Add,
 				operands: [
 					{ die: 6, count: 2 },
 					{ die: 8, count: 2 },
@@ -64,7 +84,7 @@ describe('The Command Parser', () => {
 
 			result = parseCommand<RollCommand>('roll 1d6-1d4')
 			expect(result.expr).toEqual({
-				operation: 'subtract',
+				operation: RollExpressionOpType.Subtract,
 				operands: [
 					{ die: 6, count: 1 },
 					{ die: 4, count: 1 },
@@ -73,23 +93,42 @@ describe('The Command Parser', () => {
 
 			result = parseCommand<RollCommand>('roll 1d6-1d4')
 			expect(result.expr).toEqual({
-				operation: 'subtract',
+				operation: RollExpressionOpType.Subtract,
 				operands: [
 					{ die: 6, count: 1 },
 					{ die: 4, count: 1 },
 				],
 			})
 
+			result = parseCommand<RollCommand>('roll 1d6 + 1d4 + 1d2 + 2 #stealth')
+			expect(result.label).toEqual('stealth')
+			expect(result.expr).toEqual({
+				operation: RollExpressionOpType.Add,
+				operands: [
+					{ die: 6, count: 1 },
+					{
+						operation: RollExpressionOpType.Add,
+						operands: [
+							{ die: 4, count: 1 },
+							{
+								operation: RollExpressionOpType.Add,
+								operands: [{ die: 2, count: 1 }, { value: 2 }],
+							},
+						],
+					},
+				],
+			})
+
 			result = parseCommand<RollCommand>('roll 1d6-2')
 			expect(result.expr).toEqual({
-				operation: 'subtract',
+				operation: RollExpressionOpType.Subtract,
 				operands: [{ die: 6, count: 1 }, { value: 2 }],
 			})
 
 			result = parseCommand<RollCommand>('roll d20+2 #stealth')
 			expect(result.label).toEqual('stealth')
 			expect(result.expr).toEqual({
-				operation: 'add',
+				operation: RollExpressionOpType.Add,
 				operands: [{ die: 20, count: 1 }, { value: 2 }],
 			})
 		})
@@ -103,7 +142,7 @@ describe('The Command Parser', () => {
 
 			result = parseCommand<RollCommand>('roll 2d20kl1+2d6kh2')
 			expect(result.expr).toEqual({
-				operation: 'add',
+				operation: RollExpressionOpType.Add,
 				operands: [
 					{ die: 20, count: 2, keepLowest: 1 },
 					{ die: 6, count: 2, keepHighest: 2 },

--- a/packages/parser/src/parser.ts
+++ b/packages/parser/src/parser.ts
@@ -8,6 +8,11 @@ export enum CommandType {
 	Help = 'help',
 }
 
+export enum RollExpressionOpType {
+	Add = 'add',
+	Subtract = 'subtract',
+}
+
 export interface Command {
 	type: CommandType
 }
@@ -20,7 +25,7 @@ export interface RollExpressionClause {
 }
 
 export interface RollExpressionOp {
-	operation: 'add' | 'subtract'
+	operation: RollExpressionOpType
 	operands: [RollExpression]
 }
 


### PR DESCRIPTION
Handle rolls in the form of: `<clause> + <clause>` and `<clause> - <clause>` in addition to `<clause>+<clause` and `<clause>-<clause>`